### PR TITLE
Clear output 

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --require spec_helper
+--format documentation

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -7,8 +7,8 @@ class CLI
     gets.chomp
   end
 
-  def display_board(board)
-    formatted_board = format_board_for_display board
+  def display_board(board_state)
+    formatted_board = format_board_for_display board_state
     display_message formatted_board
   end
 
@@ -18,10 +18,10 @@ class CLI
 
   private
 
-  def format_board_for_display(board)
+  def format_board_for_display(board_state)
     board_str = ''
 
-    board.each_with_index do |row, row_idx|
+    board_state.each_with_index do |row, row_idx|
       board_str += generate_board_row(row, row_idx)
     end
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -19,13 +19,13 @@ class CLI
   private
 
   def format_board_for_display(board_state)
-    board_str = ''
+    board_str = "\n"
 
     board_state.each_with_index do |row, row_idx|
       board_str += generate_board_row(row, row_idx)
     end
 
-    board_str
+    board_str + "\n"
   end
 
   def generate_board_row(row, row_idx)

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -13,7 +13,7 @@ class CLI
   end
 
   def clear_output
-    system "clear"
+    system 'clear'
   end
 
   private

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -12,6 +12,10 @@ class CLI
     display_message formatted_board
   end
 
+  def clear_output
+    system "clear"
+  end
+
   private
 
   def format_board_for_display(board)

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -1,6 +1,5 @@
 class Game
-  def initialize(game_messenger: nil, game_state: nil)
-    @game_messenger = game_messenger
+  def initialize(game_state:)
     @game_state = game_state
   end
 

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -5,6 +5,8 @@ class Game
   end
 
   def start
+    @game_messenger.clear_output
+
     @game_messenger.display_board @game_state.board
 
     until @game_state.game_over?
@@ -22,6 +24,8 @@ class Game
     @game_messenger.display message: :move_instruction
 
     @game_state.player_move
+
+    @game_messenger.clear_output
 
     @game_messenger.display_board @game_state.board
   end

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -5,15 +5,9 @@ class Game
   end
 
   def start
-    @game_messenger.clear_output
+    @game_state.print_screen_with_welcome
 
-    @game_messenger.display_board @game_state.board
-
-    until @game_state.game_over?
-      one_turn
-
-      @game_state.alternate_current_player
-    end
+    one_turn until @game_state.game_over?
 
     exit_game
   end
@@ -21,13 +15,11 @@ class Game
   private
 
   def one_turn
-    @game_messenger.display message: :move_instruction
-
     @game_state.player_move
 
-    @game_messenger.clear_output
+    @game_state.alternate_current_player
 
-    @game_messenger.display_board @game_state.board
+    @game_state.print_screen_for_move
   end
 
   def exit_game
@@ -35,10 +27,10 @@ class Game
 
     if did_player_win
       winner = @game_state.previous_player
-      @game_messenger.display message: :game_over_X_wins if winner.mark == 'X'
-      @game_messenger.display message: :game_over_O_wins if winner.mark == 'O'
+      @game_state.print_screen bottom_messages: [:game_over_X_wins] if winner.mark == 'X'
+      @game_state.print_screen bottom_messages: [:game_over_O_wins] if winner.mark == 'O'
     else
-      @game_messenger.display(message: :game_over_with_tie)
+      @game_state.print_screen bottom_messages: [:game_over_with_tie]
     end
   end
 end

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -5,7 +5,7 @@ class Game
   end
 
   def start
-    @game_state.print_screen_with_welcome
+    @game_state.display_board_with_messages_with_welcome
 
     one_turn until @game_state.game_over?
 
@@ -19,7 +19,7 @@ class Game
 
     @game_state.alternate_current_player
 
-    @game_state.print_screen_for_move
+    @game_state.display_board_with_messages_for_move
   end
 
   def exit_game
@@ -27,10 +27,10 @@ class Game
 
     if did_player_win
       winner = @game_state.previous_player
-      @game_state.print_screen bottom_messages: [:game_over_X_wins] if winner.mark == 'X'
-      @game_state.print_screen bottom_messages: [:game_over_O_wins] if winner.mark == 'O'
+      @game_state.display_board_with_messages bottom_messages: [:game_over_X_wins] if winner.mark == 'X'
+      @game_state.display_board_with_messages bottom_messages: [:game_over_O_wins] if winner.mark == 'O'
     else
-      @game_state.print_screen bottom_messages: [:game_over_with_tie]
+      @game_state.display_board_with_messages bottom_messages: [:game_over_with_tie]
     end
   end
 end

--- a/lib/game_generator.rb
+++ b/lib/game_generator.rb
@@ -7,7 +7,10 @@ require_relative './player'
 require_relative './board'
 
 MESSAGES = {
-  move_instruction: 'Enter a number to make a move in the corresponding square:',
+  welcome: 'Welcome to a game of Tic-Tac-Toe!',
+  title: 'Super TicTacToe',
+  move_instruction_x: 'Enter a number to make a move in the corresponding square (X\'s turn):',
+  move_instruction_o: 'Enter a number to make a move in the corresponding square (O\'s turn):',
   game_over_X_wins: 'Game Over: X Wins',
   game_over_O_wins: 'Game Over: O Wins',
   game_over_with_tie: 'Game Over: Tie!',
@@ -26,6 +29,7 @@ class GameGenerator
     move_validator = MoveValidator.new(game_messenger: game_messenger)
 
     game_state = GameState.new(
+      game_messenger: game_messenger,
       game_end_evaluator: GameEndEvaluator.new,
       move_validator: move_validator,
       board: Board.new,

--- a/lib/game_generator.rb
+++ b/lib/game_generator.rb
@@ -25,19 +25,15 @@ class GameGenerator
       Player.new(user_interface, 'O')
     ]
 
-    game_messenger = GameMessenger.new(user_interface: user_interface, messages: MESSAGES)
-    move_validator = MoveValidator.new(game_messenger: game_messenger)
-
     game_state = GameState.new(
-      game_messenger: game_messenger,
+      game_messenger: GameMessenger.new(user_interface: user_interface, messages: MESSAGES),
       game_end_evaluator: GameEndEvaluator.new,
-      move_validator: move_validator,
+      move_validator: MoveValidator.new,
       board: Board.new,
       players: players
     )
 
     Game.new(
-      game_messenger: game_messenger,
       game_state: game_state
     )
   end

--- a/lib/game_generator.rb
+++ b/lib/game_generator.rb
@@ -11,8 +11,8 @@ MESSAGES = {
   game_over_X_wins: 'Game Over: X Wins',
   game_over_O_wins: 'Game Over: O Wins',
   game_over_with_tie: 'Game Over: Tie!',
-  display_not_valid_integer: 'Make sure it\'s an integer and try again!',
-  display_square_unavailable: 'You can\'t make a move there, try again!'
+  not_valid_integer: 'Make sure it\'s an integer and try again!',
+  square_unavailable: 'You can\'t make a move there, try again!'
 }.freeze
 
 class GameGenerator

--- a/lib/game_messenger.rb
+++ b/lib/game_messenger.rb
@@ -1,5 +1,5 @@
 class GameMessenger
-  def initialize(user_interface:, messages: {})
+  def initialize(user_interface:, messages:)
     @messages = messages
     @user_interface = user_interface
   end

--- a/lib/game_messenger.rb
+++ b/lib/game_messenger.rb
@@ -12,11 +12,11 @@ class GameMessenger
     @user_interface.display_board board.state
   end
 
-  private
-
-  attr_reader :messages
-
   def clear_output
     @user_interface.clear_output
   end
+
+  private
+
+  attr_reader :messages
 end

--- a/lib/game_messenger.rb
+++ b/lib/game_messenger.rb
@@ -16,6 +16,17 @@ class GameMessenger
     @user_interface.clear_output
   end
 
+  def display_messages(top_message:, board:, bottom_messages:)
+    clear_output
+
+    display(message: top_message)
+    display_board(board)
+
+    bottom_messages.each do |message_key|
+      display(message: message_key)
+    end
+  end
+
   private
 
   attr_reader :messages

--- a/lib/game_messenger.rb
+++ b/lib/game_messenger.rb
@@ -16,7 +16,7 @@ class GameMessenger
     @user_interface.clear_output
   end
 
-  def display_messages(top_message:, board:, bottom_messages:)
+  def display_board_with_messages(top_message:, board:, bottom_messages:)
     clear_output
 
     display(message: top_message)

--- a/lib/game_messenger.rb
+++ b/lib/game_messenger.rb
@@ -15,4 +15,8 @@ class GameMessenger
   private
 
   attr_reader :messages
+
+  def clear_output
+    @user_interface.clear_output
+  end
 end

--- a/lib/game_state.rb
+++ b/lib/game_state.rb
@@ -24,21 +24,25 @@ class GameState
         break
       end
 
-      print_screen_for_move bottom_messages: [error_symbol]
+      display_board_with_messages_for_move bottom_messages: [error_symbol]
     end
   end
 
-  def print_screen_with_welcome
-    print_screen_for_move top_message: :welcome
+  def display_board_with_messages_with_welcome
+    display_board_with_messages_for_move_for_move top_message: :welcome
   end
 
-  def print_screen_for_move(top_message: :title, bottom_messages: [])
+  def display_board_with_messages_for_move(top_message: :title, bottom_messages: [])
     bottom_message_symbols = bottom_messages.push(instruction_symbol)
-    print_screen top_message: top_message, bottom_messages: bottom_message_symbols
+    display_board_with_messages top_message: top_message, bottom_messages: bottom_message_symbols
   end
 
-  def print_screen(top_message: :title, bottom_messages: [])
-    @game_messenger.display_messages top_message: top_message, board: @board, bottom_messages: bottom_messages
+  def display_board_with_messages(top_message: :title, bottom_messages: [])
+    @game_messenger.display_board_with_messages(
+      top_message: top_message,
+      board: @board,
+      bottom_messages: bottom_messages
+    )
   end
 
   def game_over?

--- a/lib/game_state.rb
+++ b/lib/game_state.rb
@@ -17,7 +17,7 @@ class GameState
   def player_move
     loop do
       position = current_player.get_move
-      error = valid_move?(position)
+      error = check_for_error(position)
 
       if error.nil?
         @board.update(current_player.mark, position)
@@ -64,8 +64,8 @@ class GameState
     @current_player_idx.zero? ? :move_instruction_x : :move_instruction_o
   end
 
-  def valid_move?(position)
-    @move_validator.error_for_move(@board, position)
+  def check_for_error(position)
+    @move_validator.move_error(@board, position)
   end
 
   def current_player

--- a/lib/game_state.rb
+++ b/lib/game_state.rb
@@ -29,7 +29,7 @@ class GameState
   end
 
   def display_board_with_messages_with_welcome
-    display_board_with_messages_for_move_for_move top_message: :welcome
+    display_board_with_messages_for_move top_message: :welcome
   end
 
   def display_board_with_messages_for_move(top_message: :title, bottom_messages: [])

--- a/lib/game_state.rb
+++ b/lib/game_state.rb
@@ -17,14 +17,14 @@ class GameState
   def player_move
     loop do
       position = current_player.get_move
-      error_symbol = valid_move?(position)
+      error = valid_move?(position)
 
-      if error_symbol.nil?
+      if error.nil?
         @board.update(current_player.mark, position)
         break
       end
 
-      display_board_with_messages_for_move bottom_messages: [error_symbol]
+      display_board_with_messages_for_move bottom_messages: [error]
     end
   end
 

--- a/lib/game_state.rb
+++ b/lib/game_state.rb
@@ -1,7 +1,8 @@
 class GameState
   attr_reader :board
 
-  def initialize(game_end_evaluator: nil, move_validator: nil, board: nil, players: nil)
+  def initialize(game_messenger:, game_end_evaluator: nil, move_validator: nil, board: nil, players: nil)
+    @game_messenger = game_messenger
     @game_end_evaluator = game_end_evaluator
     @move_validator = move_validator
     @board = board
@@ -16,12 +17,28 @@ class GameState
   def player_move
     loop do
       position = current_player.get_move
+      error_symbol = valid_move?(position)
 
-      if valid_move?(position)
+      if error_symbol.nil?
         @board.update(current_player.mark, position)
         break
       end
+
+      print_screen_for_move bottom_messages: [error_symbol]
     end
+  end
+
+  def print_screen_with_welcome
+    print_screen_for_move top_message: :welcome
+  end
+
+  def print_screen_for_move(top_message: :title, bottom_messages: [])
+    bottom_message_symbols = bottom_messages.push(instruction_symbol)
+    print_screen top_message: top_message, bottom_messages: bottom_message_symbols
+  end
+
+  def print_screen(top_message: :title, bottom_messages: [])
+    @game_messenger.display_messages top_message: top_message, board: @board, bottom_messages: bottom_messages
   end
 
   def game_over?
@@ -39,8 +56,12 @@ class GameState
 
   private
 
+  def instruction_symbol
+    @current_player_idx.zero? ? :move_instruction_x : :move_instruction_o
+  end
+
   def valid_move?(position)
-    @move_validator.move_valid?(@board, position)
+    @move_validator.error_for_move(@board, position)
   end
 
   def current_player

--- a/lib/game_state.rb
+++ b/lib/game_state.rb
@@ -1,7 +1,7 @@
 class GameState
   attr_reader :board
 
-  def initialize(game_messenger:, game_end_evaluator: nil, move_validator: nil, board: nil, players: nil)
+  def initialize(game_messenger:, game_end_evaluator:, move_validator:, board:, players:)
     @game_messenger = game_messenger
     @game_end_evaluator = game_end_evaluator
     @move_validator = move_validator

--- a/lib/move_validator.rb
+++ b/lib/move_validator.rb
@@ -1,15 +1,15 @@
 class MoveValidator
-  def error_for_move(board, position_input)
-    error_for_integer(position_input) || error_for_square(board, position_input)
+  def move_error(board, position_input)
+    input_error(position_input) || position_error(board, position_input)
   end
 
   private
 
-  def error_for_integer(pos_input)
+  def input_error(pos_input)
     return :not_valid_integer unless int_or_str?(pos_input) && parses_to_integer?(pos_input)
   end
 
-  def error_for_square(board, position)
+  def position_error(board, position)
     return :square_unavailable unless board.position_available? position
   end
 

--- a/lib/move_validator.rb
+++ b/lib/move_validator.rb
@@ -3,27 +3,18 @@ class MoveValidator
     @game_messenger = game_messenger
   end
 
-  def move_valid?(board, position_input)
-    valid_integer?(position_input) && empty_square?(board, position_input)
+  def error_for_move(board, position_input)
+    error_for_integer(position_input) || error_for_square(board, position_input)
   end
 
   private
 
-  def valid_integer?(pos_input)
-    if !int_or_str?(pos_input) || !parses_to_integer?(pos_input)
-      @game_messenger.display(message: :not_valid_integer)
-      return false
-    end
-
-    true
+  def error_for_integer(pos_input)
+    return :not_valid_integer unless int_or_str?(pos_input) && parses_to_integer?(pos_input)
   end
 
-  def empty_square?(board, position)
-    is_empty = board.position_available? position
-
-    @game_messenger.display(message: :square_unavailable) unless is_empty
-
-    is_empty
+  def error_for_square(board, position)
+    return :square_unavailable unless board.position_available? position
   end
 
   def int_or_str?(position_input)

--- a/lib/move_validator.rb
+++ b/lib/move_validator.rb
@@ -21,7 +21,7 @@ class MoveValidator
   def empty_square?(board, position)
     is_empty = board.position_available? position
 
-    @game_messenger.display(message: :square_unavaliable) unless is_empty
+    @game_messenger.display(message: :square_unavailable) unless is_empty
 
     is_empty
   end

--- a/lib/move_validator.rb
+++ b/lib/move_validator.rb
@@ -1,8 +1,4 @@
 class MoveValidator
-  def initialize(game_messenger: nil)
-    @game_messenger = game_messenger
-  end
-
   def error_for_move(board, position_input)
     error_for_integer(position_input) || error_for_square(board, position_input)
   end

--- a/lib/tic_tac_toe.rb
+++ b/lib/tic_tac_toe.rb
@@ -7,7 +7,7 @@ class TicTacToe
   end
 
   def start
-    # @game_messenger.clear_output
+    @user_interface.clear_output
 
     display_welcome
 

--- a/lib/tic_tac_toe.rb
+++ b/lib/tic_tac_toe.rb
@@ -7,6 +7,8 @@ class TicTacToe
   end
 
   def start
+    # @game_messenger.clear_output
+
     display_welcome
 
     game = create_a_game

--- a/lib/user_interface.rb
+++ b/lib/user_interface.rb
@@ -7,8 +7,8 @@ class UserInterface
     @platform.display_message message
   end
 
-  def display_board(board)
-    @platform.display_board board
+  def display_board(board_state)
+    @platform.display_board board_state
   end
 
   def get_user_input

--- a/lib/user_interface.rb
+++ b/lib/user_interface.rb
@@ -14,4 +14,8 @@ class UserInterface
   def get_user_input
     @platform.get_user_input
   end
+
+  def clear_output
+    @platform.clear_output
+  end
 end

--- a/spec/lib/game_messenger_spec.rb
+++ b/spec/lib/game_messenger_spec.rb
@@ -1,27 +1,30 @@
 require_relative '../../lib/player'
 require_relative '../../lib/game_messenger'
 
-RSpec.describe GameMessenger do
-  let(:cli) { CLI.new }
-  let(:user_interface) { UserInterface.new(cli) }
-  let(:game_messenger) { GameMessenger.new(user_interface: user_interface) }
-  let(:player) { Player.new(user_interface, 'X') }
-
-  class TestUserInterface
-    def display_message(message)
-      'Displayed: ' + message
-    end
+class TestUserInterface
+  def display_message(message)
+    'Displayed: ' + message
   end
+
+  def display_board(board_state)
+    board_str = board_state.flatten.map { |square| square || 'nil' }
+    'Displayed: ' + board_str.join(',')
+  end
+end
+
+GAME_MESSENGER_MESSAGES = {
+  hello: 'Hello',
+  bye: 'Bye'
+}.freeze
+
+RSpec.describe GameMessenger do
+  let(:board) { Board.new }
+  let(:test_user_interface) { TestUserInterface.new }
+  let(:game_messenger) { GameMessenger.new(user_interface: test_user_interface, messages: GAME_MESSENGER_MESSAGES) }
+  let(:player) { Player.new(user_interface, 'X') }
 
   describe 'display' do
     it 'should display the associated message given a symbol' do
-      messages = {
-        hello: 'Hello',
-        bye: 'Bye'
-      }
-      test_user_interface = TestUserInterface.new
-      game_messenger = GameMessenger.new(user_interface: test_user_interface, messages: messages)
-
       displayed_message = game_messenger.display message: :hello
       expect(displayed_message).to eq('Displayed: Hello')
 

--- a/spec/lib/game_messenger_spec.rb
+++ b/spec/lib/game_messenger_spec.rb
@@ -2,18 +2,31 @@ require_relative '../../lib/player'
 require_relative '../../lib/game_messenger'
 
 class TestUserInterface
+  attr_reader :displayed_messages
+  def initialize
+    @displayed_messages = []
+  end
+
   def display_message(message)
+    raise ArgumentError, 'Argument must be a string' unless message.is_a? String
+
+    @displayed_messages.push message
     'Displayed: ' + message
   end
 
   def display_board(board_state)
     board_str = board_state.flatten.map { |square| square || 'nil' }
-    'Displayed: ' + board_str.join(',')
+    @displayed_messages.push board_str.join(',')
+  end
+
+  def clear_output
+    @displayed_messages.push 'Cleared'
   end
 end
 
 GAME_MESSENGER_MESSAGES = {
   hello: 'Hello',
+  instruction: 'Make your move',
   bye: 'Bye'
 }.freeze
 
@@ -30,6 +43,31 @@ RSpec.describe GameMessenger do
 
       displayed_message = game_messenger.display message: :bye
       expect(displayed_message).to eq('Displayed: Bye')
+    end
+  end
+
+  describe 'display' do
+    let(:displayed_messages) do
+      game_messenger.display_messages top_message: :hello, board: board, bottom_messages: %i[instruction bye]
+      test_ui = game_messenger.instance_variable_get(:@user_interface)
+      test_ui.displayed_messages
+    end
+
+    it 'should clear all output' do
+      expect(displayed_messages[0]).to eq('Cleared')
+    end
+
+    it 'should display top message' do
+      expect(displayed_messages[1]).to eq('Hello')
+    end
+
+    it 'should display board' do
+      expect(displayed_messages[2]).to eq('nil,nil,nil,nil,nil,nil,nil,nil,nil')
+    end
+
+    it 'should display bottom messages in order' do
+      expect(displayed_messages[3]).to eq('Make your move')
+      expect(displayed_messages[4]).to eq('Bye')
     end
   end
 end

--- a/spec/lib/game_spec.rb
+++ b/spec/lib/game_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe Game do
     ]
 
     GameState.new(
+      game_messenger: game_messenger,
       game_end_evaluator: GameEndEvaluator.new,
+      move_validator: MoveValidator.new,
       board: Board.new,
       players: players
     )
@@ -28,19 +30,20 @@ RSpec.describe Game do
 
   describe 'start' do
     it 'should go through the loop and exit with a tie' do
-      expect(game_messenger).to receive(:clear_output).ordered
-      expect(game_messenger).to receive(:display_board).with(game_state.board).ordered
+      expect(game_state).to receive(:print_screen_with_welcome).ordered
 
       # loop
       expect(game_state).to receive(:game_over?).ordered.and_return false
-      expect(game_messenger).to receive(:display).ordered.with(message: :move_instruction)
       expect(game_state).to receive(:player_move).ordered
-      expect(game_messenger).to receive(:clear_output).ordered
-      expect(game_messenger).to receive(:display_board).with(game_state.board).ordered
+      expect(game_state).to receive(:alternate_current_player).ordered
+      expect(game_state).to receive(:print_screen_for_move).ordered
+
       expect(game_state).to receive(:game_over?).ordered.and_return true
 
       # exit game
-      expect(game_messenger).to receive(:display).ordered.with(message: :game_over_with_tie)
+      expect(game_state).to receive(:player_won?).ordered.and_return false
+
+      expect(game_state).to receive(:print_screen).ordered.with(bottom_messages: [:game_over_with_tie])
 
       game.start
     end
@@ -57,13 +60,13 @@ RSpec.describe Game do
       game_state.instance_variable_set(:@board, board)
       game_state.instance_variable_set(:@current_player_idx, 1)
 
-      allow(game_messenger).to receive(:clear_output)
-      allow(game_messenger).to receive(:display_board)
+      expect(game_state).to receive(:print_screen_with_welcome).ordered
 
       # loop
       allow(game_state).to receive(:game_over?).and_return(true)
 
       # exit game
+      expect(game_messenger).to receive(:display).ordered.with(message: :title)
       expect(game_messenger).to receive(:display).with(message: :game_over_X_wins)
 
       game.start

--- a/spec/lib/game_spec.rb
+++ b/spec/lib/game_spec.rb
@@ -30,20 +30,20 @@ RSpec.describe Game do
 
   describe 'start' do
     it 'should go through the loop and exit with a tie' do
-      expect(game_state).to receive(:print_screen_with_welcome).ordered
+      expect(game_state).to receive(:display_board_with_messages_with_welcome).ordered
 
       # loop
       expect(game_state).to receive(:game_over?).ordered.and_return false
       expect(game_state).to receive(:player_move).ordered
       expect(game_state).to receive(:alternate_current_player).ordered
-      expect(game_state).to receive(:print_screen_for_move).ordered
+      expect(game_state).to receive(:display_board_with_messages_for_move).ordered
 
       expect(game_state).to receive(:game_over?).ordered.and_return true
 
       # exit game
       expect(game_state).to receive(:player_won?).ordered.and_return false
 
-      expect(game_state).to receive(:print_screen).ordered.with(bottom_messages: [:game_over_with_tie])
+      expect(game_state).to receive(:display_board_with_messages).ordered.with(bottom_messages: [:game_over_with_tie])
 
       game.start
     end
@@ -60,7 +60,7 @@ RSpec.describe Game do
       game_state.instance_variable_set(:@board, board)
       game_state.instance_variable_set(:@current_player_idx, 1)
 
-      expect(game_state).to receive(:print_screen_with_welcome).ordered
+      expect(game_state).to receive(:display_board_with_messages_with_welcome).ordered
 
       # loop
       allow(game_state).to receive(:game_over?).and_return(true)

--- a/spec/lib/game_spec.rb
+++ b/spec/lib/game_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Game do
 
       # exit game
       expect(game_messenger).to receive(:display).ordered.with(message: :title)
+      expect(game_messenger).to receive(:display_board).ordered
       expect(game_messenger).to receive(:display).with(message: :game_over_X_wins)
 
       game.start

--- a/spec/lib/game_spec.rb
+++ b/spec/lib/game_spec.rb
@@ -28,12 +28,14 @@ RSpec.describe Game do
 
   describe 'start' do
     it 'should go through the loop and exit with a tie' do
+      expect(game_messenger).to receive(:clear_output).ordered
       expect(game_messenger).to receive(:display_board).with(game_state.board).ordered
 
       # loop
       expect(game_state).to receive(:game_over?).ordered.and_return false
       expect(game_messenger).to receive(:display).ordered.with(message: :move_instruction)
       expect(game_state).to receive(:player_move).ordered
+      expect(game_messenger).to receive(:clear_output).ordered
       expect(game_messenger).to receive(:display_board).with(game_state.board).ordered
       expect(game_state).to receive(:game_over?).ordered.and_return true
 
@@ -55,6 +57,7 @@ RSpec.describe Game do
       game_state.instance_variable_set(:@board, board)
       game_state.instance_variable_set(:@current_player_idx, 1)
 
+      allow(game_messenger).to receive(:clear_output)
       allow(game_messenger).to receive(:display_board)
 
       # loop

--- a/spec/lib/game_spec.rb
+++ b/spec/lib/game_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Game do
     cli = CLI.new
     UserInterface.new(cli)
   end
-  let(:game_messenger) { GameMessenger.new(user_interface: ui) }
+  let(:game_messenger) { GameMessenger.new(user_interface: ui, messages: {}) }
   let(:game_state) do
     players = [
       Player.new(ui, 'X'),
@@ -23,7 +23,6 @@ RSpec.describe Game do
 
   let(:game) do
     Game.new(
-      game_messenger: game_messenger,
       game_state: game_state
     )
   end

--- a/spec/lib/game_state_spec.rb
+++ b/spec/lib/game_state_spec.rb
@@ -2,12 +2,53 @@ require_relative '../../lib/player'
 require_relative '../../lib/game_state'
 require_relative '../../lib/move_validator'
 
-RSpec.describe GameState do
-  let(:ui) do
-    cli = CLI.new
-    UserInterface.new(cli)
+class TestCLI
+  attr_reader :diplayed_messages, :triggered_actions
+  def initialize
+    @diplayed_messages = []
+    @triggered_actions = []
   end
-  let(:game_messenger) { GameMessenger.new(user_interface: ui) }
+
+  def display_message(message)
+    @diplayed_messages.push message
+    @triggered_actions.push 'display_message'
+
+    nil
+  end
+
+  def display_board(board_state)
+    return nil unless board_state.is_a? Array
+
+    board_str = board_state.flatten.map { |square| square || 'nil' }
+
+    @triggered_actions.push 'display_board'
+
+    display_message board_str.join(',')
+  end
+
+  def clear_output
+    @triggered_actions.push 'clear_output'
+
+    true
+  end
+end
+
+MESSAGES = {
+  welcome: 'Welcome to a game of Tic-Tac-Toe!',
+  title: 'Super TicTacToe',
+  move_instruction_x: 'Enter a number to make a move in the corresponding square (X\'s turn):',
+  move_instruction_o: 'Enter a number to make a move in the corresponding square (O\'s turn):',
+  game_over_X_wins: 'Game Over: X Wins',
+  game_over_O_wins: 'Game Over: O Wins',
+  game_over_with_tie: 'Game Over: Tie!',
+  not_valid_integer: 'Make sure it\'s an integer and try again!',
+  square_unavailable: 'You can\'t make a move there, try again!'
+}.freeze
+
+RSpec.describe GameState do
+  let(:ui) { UserInterface.new(TestCLI.new) }
+  let(:game_messenger) { GameMessenger.new(user_interface: ui, messages: MESSAGES) }
+  let(:board) { Board.new }
   let(:game_state) do
     players = [
       Player.new(ui, 'X'),
@@ -20,7 +61,7 @@ RSpec.describe GameState do
       game_messenger: game_messenger,
       game_end_evaluator: GameEndEvaluator.new,
       move_validator: move_validator,
-      board: Board.new,
+      board: board,
       players: players
     )
   end
@@ -48,8 +89,6 @@ RSpec.describe GameState do
       players = game_state.instance_variable_get(:@players)
       player_one = players[current_player_idx]
 
-      board = game_state.instance_variable_get(:@board)
-
       move_validator = game_state.instance_variable_get(:@move_validator)
       allow(move_validator).to receive(:error_for_integer).and_return nil
       allow(move_validator).to receive(:error_for_square).and_return nil
@@ -65,8 +104,6 @@ RSpec.describe GameState do
       current_player_idx = game_state.instance_variable_get(:@current_player_idx)
       players = game_state.instance_variable_get(:@players)
       player_one = players[current_player_idx]
-
-      board = game_state.instance_variable_get(:@board)
 
       move_validator = game_state.instance_variable_get(:@move_validator)
       allow(move_validator).to receive(:error_for_integer).and_return(:not_valid_integer, nil)
@@ -86,8 +123,6 @@ RSpec.describe GameState do
       current_player_idx = game_state.instance_variable_get(:@current_player_idx)
       players = game_state.instance_variable_get(:@players)
       player_one = players[current_player_idx]
-
-      board = game_state.instance_variable_get(:@board)
 
       move_validator = game_state.instance_variable_get(:@move_validator)
       allow(move_validator).to receive(:error_for_integer).and_return(nil)
@@ -115,6 +150,39 @@ RSpec.describe GameState do
       player = game_state.previous_player
 
       expect(player.mark).to eq('X')
+    end
+  end
+
+  describe 'display_board_with_messages' do
+    let(:test_cli) do
+      game_state.display_board_with_messages(
+        top_message: :welcome,
+        bottom_messages: [:move_instruction_o]
+      )
+
+      ui.instance_variable_get(:@platform)
+    end
+
+    it 'should print clear output first' do
+      expect(test_cli.triggered_actions[0]).to eq 'clear_output'
+    end
+
+    it 'should print the top message' do
+      expect(test_cli.triggered_actions[1]).to eq 'display_message'
+      expect(test_cli.diplayed_messages[0]).to eq 'Welcome to a game of Tic-Tac-Toe!'
+    end
+
+    it 'should print the board' do
+      expect(test_cli.triggered_actions[2]).to eq 'display_board'
+      expect(test_cli.triggered_actions[3]).to eq 'display_message'
+      expect(test_cli.diplayed_messages[1]).to eq 'nil,nil,nil,nil,nil,nil,nil,nil,nil'
+    end
+
+    it 'should print the bottom message' do
+      expect(test_cli.triggered_actions[4]).to eq 'display_message'
+      expect(test_cli.diplayed_messages[2]).to eq(
+        'Enter a number to make a move in the corresponding square (O\'s turn):'
+      )
     end
   end
 end

--- a/spec/lib/game_state_spec.rb
+++ b/spec/lib/game_state_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe GameState do
       allow(move_validator).to receive(:error_for_integer).and_return(:not_valid_integer, nil)
       allow(move_validator).to receive(:error_for_square).and_return(nil)
 
-      allow(game_state).to receive(:print_screen)
+      allow(game_state).to receive(:display_board_with_messages)
 
       invalid_pos_str = 'abc'
       pos_str = '9'
@@ -93,7 +93,7 @@ RSpec.describe GameState do
       allow(move_validator).to receive(:error_for_integer).and_return(nil)
       allow(move_validator).to receive(:error_for_square).and_return(:square_unavailable, nil)
 
-      allow(game_state).to receive(:print_screen)
+      allow(game_state).to receive(:display_board_with_messages)
 
       invalid_pos_str = '1'
       pos_str = '9'

--- a/spec/lib/game_state_spec.rb
+++ b/spec/lib/game_state_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe GameState do
       players = game_state.instance_variable_get(:@players)
       player_one = players[current_player_idx]
 
-      allow(move_validator).to receive(:error_for_integer).and_return nil
-      allow(move_validator).to receive(:error_for_square).and_return nil
+      allow(move_validator).to receive(:input_error).and_return nil
+      allow(move_validator).to receive(:position_error).and_return nil
 
       pos_str = '9'
       expect(player_one).to receive(:get_move).and_return pos_str
@@ -73,8 +73,8 @@ RSpec.describe GameState do
       players = game_state.instance_variable_get(:@players)
       player_one = players[current_player_idx]
 
-      allow(move_validator).to receive(:error_for_integer).and_return(:not_valid_integer, nil)
-      allow(move_validator).to receive(:error_for_square).and_return(nil)
+      allow(move_validator).to receive(:input_error).and_return(:not_valid_integer, nil)
+      allow(move_validator).to receive(:position_error).and_return(nil)
 
       allow(game_state).to receive(:display_board_with_messages)
 
@@ -91,8 +91,8 @@ RSpec.describe GameState do
       players = game_state.instance_variable_get(:@players)
       player_one = players[current_player_idx]
 
-      allow(move_validator).to receive(:error_for_integer).and_return(nil)
-      allow(move_validator).to receive(:error_for_square).and_return(:square_unavailable, nil)
+      allow(move_validator).to receive(:input_error).and_return(nil)
+      allow(move_validator).to receive(:position_error).and_return(:square_unavailable, nil)
 
       allow(game_state).to receive(:display_board_with_messages)
 

--- a/spec/lib/game_state_spec.rb
+++ b/spec/lib/game_state_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe GameState do
     move_validator = MoveValidator.new(game_messenger: game_messenger)
 
     GameState.new(
+      game_messenger: game_messenger,
       game_end_evaluator: GameEndEvaluator.new,
       move_validator: move_validator,
       board: Board.new,
@@ -50,8 +51,8 @@ RSpec.describe GameState do
       board = game_state.instance_variable_get(:@board)
 
       move_validator = game_state.instance_variable_get(:@move_validator)
-      allow(move_validator).to receive(:valid_integer?).and_return true
-      allow(move_validator).to receive(:empty_square?).and_return true
+      allow(move_validator).to receive(:error_for_integer).and_return nil
+      allow(move_validator).to receive(:error_for_square).and_return nil
 
       pos_str = '9'
       expect(player_one).to receive(:get_move).and_return pos_str
@@ -68,8 +69,8 @@ RSpec.describe GameState do
       board = game_state.instance_variable_get(:@board)
 
       move_validator = game_state.instance_variable_get(:@move_validator)
-      allow(move_validator).to receive(:valid_integer?).and_return(false, true)
-      allow(move_validator).to receive(:empty_square?).and_return(true)
+      allow(move_validator).to receive(:error_for_integer).and_return(:not_valid_integer, nil)
+      allow(move_validator).to receive(:error_for_square).and_return(nil)
 
       invalid_pos_str = 'abc'
       pos_str = '9'
@@ -87,8 +88,8 @@ RSpec.describe GameState do
       board = game_state.instance_variable_get(:@board)
 
       move_validator = game_state.instance_variable_get(:@move_validator)
-      allow(move_validator).to receive(:valid_integer?).and_return(true)
-      allow(move_validator).to receive(:empty_square?).and_return(false, true)
+      allow(move_validator).to receive(:error_for_integer).and_return(nil)
+      allow(move_validator).to receive(:error_for_square).and_return(:square_unavailable, nil)
 
       invalid_pos_str = '1'
       pos_str = '9'

--- a/spec/lib/game_state_spec.rb
+++ b/spec/lib/game_state_spec.rb
@@ -151,4 +151,42 @@ RSpec.describe GameState do
       )
     end
   end
+
+  describe 'display_board_with_messages_with_welcome' do
+    it 'should display welcome message along with board' do
+      expect(game_state).to receive(:display_board_with_messages_for_move).with(top_message: :welcome)
+      game_state.display_board_with_messages_with_welcome
+    end
+  end
+
+  describe 'display_board_with_messages_for_move' do
+    it 'should add instruction to bottom message' do
+      expect(game_state).to receive(:display_board_with_messages).with(
+        top_message: :test,
+        bottom_messages: %i[second_test move_instruction_x]
+      )
+
+      game_state.display_board_with_messages_for_move(top_message: :test, bottom_messages: [:second_test])
+    end
+
+    it 'should display the appropriate instructions based on the current played index' do
+      game_state.instance_variable_set(:@current_player_idx, 1)
+      expect(game_state).to receive(:display_board_with_messages).with(
+        top_message: :test,
+        bottom_messages: %i[second_test move_instruction_o]
+      )
+
+      game_state.display_board_with_messages_for_move(top_message: :test, bottom_messages: [:second_test])
+    end
+
+    it 'should display default messages if nothing is passed in' do
+      game_state.instance_variable_set(:@current_player_idx, 1)
+      expect(game_state).to receive(:display_board_with_messages).with(
+        top_message: :title,
+        bottom_messages: [:move_instruction_o]
+      )
+
+      game_state.display_board_with_messages_for_move
+    end
+  end
 end

--- a/spec/lib/game_state_spec.rb
+++ b/spec/lib/game_state_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe GameState do
       allow(move_validator).to receive(:error_for_integer).and_return(:not_valid_integer, nil)
       allow(move_validator).to receive(:error_for_square).and_return(nil)
 
+      allow(game_state).to receive(:print_screen)
+
       invalid_pos_str = 'abc'
       pos_str = '9'
       expect(player_one).to receive(:get_move).and_return(invalid_pos_str, pos_str)
@@ -90,6 +92,8 @@ RSpec.describe GameState do
       move_validator = game_state.instance_variable_get(:@move_validator)
       allow(move_validator).to receive(:error_for_integer).and_return(nil)
       allow(move_validator).to receive(:error_for_square).and_return(:square_unavailable, nil)
+
+      allow(game_state).to receive(:print_screen)
 
       invalid_pos_str = '1'
       pos_str = '9'

--- a/spec/lib/game_state_spec.rb
+++ b/spec/lib/game_state_spec.rb
@@ -1,37 +1,7 @@
 require_relative '../../lib/player'
 require_relative '../../lib/game_state'
 require_relative '../../lib/move_validator'
-
-class TestCLI
-  attr_reader :diplayed_messages, :triggered_actions
-  def initialize
-    @diplayed_messages = []
-    @triggered_actions = []
-  end
-
-  def display_message(message)
-    @diplayed_messages.push message
-    @triggered_actions.push 'display_message'
-
-    nil
-  end
-
-  def display_board(board_state)
-    return nil unless board_state.is_a? Array
-
-    board_str = board_state.flatten.map { |square| square || 'nil' }
-
-    @triggered_actions.push 'display_board'
-
-    display_message board_str.join(',')
-  end
-
-  def clear_output
-    @triggered_actions.push 'clear_output'
-
-    true
-  end
-end
+require_relative './mock_classes/cli_mock'
 
 MESSAGES = {
   welcome: 'Welcome to a game of Tic-Tac-Toe!',

--- a/spec/lib/game_state_spec.rb
+++ b/spec/lib/game_state_spec.rb
@@ -19,13 +19,12 @@ RSpec.describe GameState do
   let(:ui) { UserInterface.new(TestCLI.new) }
   let(:game_messenger) { GameMessenger.new(user_interface: ui, messages: MESSAGES) }
   let(:board) { Board.new }
+  let(:move_validator) { MoveValidator.new }
   let(:game_state) do
     players = [
       Player.new(ui, 'X'),
       Player.new(ui, 'O')
     ]
-
-    move_validator = MoveValidator.new(game_messenger: game_messenger)
 
     GameState.new(
       game_messenger: game_messenger,
@@ -59,7 +58,6 @@ RSpec.describe GameState do
       players = game_state.instance_variable_get(:@players)
       player_one = players[current_player_idx]
 
-      move_validator = game_state.instance_variable_get(:@move_validator)
       allow(move_validator).to receive(:error_for_integer).and_return nil
       allow(move_validator).to receive(:error_for_square).and_return nil
 
@@ -75,7 +73,6 @@ RSpec.describe GameState do
       players = game_state.instance_variable_get(:@players)
       player_one = players[current_player_idx]
 
-      move_validator = game_state.instance_variable_get(:@move_validator)
       allow(move_validator).to receive(:error_for_integer).and_return(:not_valid_integer, nil)
       allow(move_validator).to receive(:error_for_square).and_return(nil)
 
@@ -94,7 +91,6 @@ RSpec.describe GameState do
       players = game_state.instance_variable_get(:@players)
       player_one = players[current_player_idx]
 
-      move_validator = game_state.instance_variable_get(:@move_validator)
       allow(move_validator).to receive(:error_for_integer).and_return(nil)
       allow(move_validator).to receive(:error_for_square).and_return(:square_unavailable, nil)
 

--- a/spec/lib/mock_classes/cli_mock.rb
+++ b/spec/lib/mock_classes/cli_mock.rb
@@ -1,0 +1,30 @@
+class TestCLI
+  attr_reader :diplayed_messages, :triggered_actions
+  def initialize
+    @diplayed_messages = []
+    @triggered_actions = []
+  end
+
+  def display_message(message)
+    @diplayed_messages.push message
+    @triggered_actions.push 'display_message'
+
+    nil
+  end
+
+  def display_board(board_state)
+    return nil unless board_state.is_a? Array
+
+    board_str = board_state.flatten.map { |square| square || 'nil' }
+
+    @triggered_actions.push 'display_board'
+
+    display_message board_str.join(',')
+  end
+
+  def clear_output
+    @triggered_actions.push 'clear_output'
+
+    true
+  end
+end

--- a/spec/lib/move_validator_spec.rb
+++ b/spec/lib/move_validator_spec.rb
@@ -9,92 +9,68 @@ RSpec.describe MoveValidator do
   let(:move_validator) { MoveValidator.new(game_messenger: game_messenger) }
   let(:board) { Board.new }
 
-  describe 'move_valid?' do
+  describe 'error_for_move' do
     it 'should return true given an integer as a string' do
-      is_valid = move_validator.move_valid?(board, '2')
+      error_symbol = move_validator.error_for_move(board, '2')
 
-      expect(is_valid).to be true
+      expect(error_symbol).to be nil
     end
 
     it 'should return true given an integer as a string surrounded by whitespace' do
-      is_valid = move_validator.move_valid?(board, ' 2 ')
+      error_symbol = move_validator.error_for_move(board, ' 2 ')
 
-      expect(is_valid).to be true
+      expect(error_symbol).to be nil
     end
 
     it 'should return false given a non-integer string' do
-      expect(game_messenger).to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).not_to receive(:display).with(message: :square_unavailable)
+      error_symbol = move_validator.error_for_move(board, '1one')
 
-      is_valid = move_validator.move_valid?(board, '1one')
-
-      expect(is_valid).to be false
+      expect(error_symbol).to eq :not_valid_integer
     end
 
     it 'should return false given a float' do
-      expect(game_messenger).to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).not_to receive(:display).with(message: :square_unavailable)
+      error_symbol = move_validator.error_for_move(board, 1.0)
 
-      is_valid = move_validator.move_valid?(board, 1.0)
-
-      expect(is_valid).to be false
+      expect(error_symbol).to eq :not_valid_integer
     end
 
     it 'should return false given nil' do
-      expect(game_messenger).to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).not_to receive(:display).with(message: :square_unavailable)
+      error_symbol = move_validator.error_for_move(board, nil)
 
-      is_valid = move_validator.move_valid?(board, nil)
-
-      expect(is_valid).to be false
+      expect(error_symbol).to eq :not_valid_integer
     end
 
     it 'should return false given white space' do
-      expect(game_messenger).to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).not_to receive(:display).with(message: :square_unavailable)
+      error_symbol = move_validator.error_for_move(board, ' ')
 
-      is_valid = move_validator.move_valid?(board, ' ')
-
-      expect(is_valid).to be false
+      expect(error_symbol).to eq :not_valid_integer
     end
 
     it 'should return false given special characters' do
-      expect(game_messenger).to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).not_to receive(:display).with(message: :square_unavailable)
+      error_symbol = move_validator.error_for_move(board, '!')
 
-      is_valid = move_validator.move_valid?(board, '!')
-
-      expect(is_valid).to be false
+      expect(error_symbol).to eq :not_valid_integer
     end
 
     it 'should return true given the square is empty' do
-      is_valid = move_validator.move_valid?(board, 1)
+      error_symbol = move_validator.error_for_move(board, 1)
 
-      expect(is_valid).to be true
+      expect(error_symbol).to be nil
     end
 
     it 'should return false given a position less than 1' do
-      expect(game_messenger).not_to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).to receive(:display).with(message: :square_unavailable)
+      error_symbol = move_validator.error_for_move(board, 0)
 
-      is_valid = move_validator.move_valid?(board, 0)
-
-      expect(is_valid).to be false
+      expect(error_symbol).to eq :square_unavailable
     end
 
     it 'should return false given a position greater than 9' do
-      expect(game_messenger).not_to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).to receive(:display).with(message: :square_unavailable)
+      error_symbol = move_validator.error_for_move(board, 10)
 
-      is_valid = move_validator.move_valid?(board, 10)
-
-      expect(is_valid).to be false
+      expect(error_symbol).to eq :square_unavailable
     end
 
     it 'should return false if the square is occupied' do
-      expect(game_messenger).not_to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).to receive(:display).with(message: :square_unavailable)
-
       board_played_at_one = [
         ['X', nil, nil],
         [nil, nil, nil],
@@ -103,9 +79,9 @@ RSpec.describe MoveValidator do
 
       board.instance_variable_set(:@board, board_played_at_one)
 
-      is_valid = move_validator.move_valid?(board, 1)
+      error_symbol = move_validator.error_for_move(board, 1)
 
-      expect(is_valid).to be false
+      expect(error_symbol).to eq :square_unavailable
     end
   end
 end

--- a/spec/lib/move_validator_spec.rb
+++ b/spec/lib/move_validator_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe MoveValidator do
     cli = CLI.new
     UserInterface.new(cli)
   end
-  let(:game_messenger) { GameMessenger.new(user_interface: ui) }
-  let(:move_validator) { MoveValidator.new(game_messenger: game_messenger) }
+  let(:game_messenger) { GameMessenger.new(user_interface: ui, messages: {}) }
+  let(:move_validator) { MoveValidator.new }
   let(:board) { Board.new }
 
   describe 'error_for_move' do

--- a/spec/lib/move_validator_spec.rb
+++ b/spec/lib/move_validator_spec.rb
@@ -9,63 +9,63 @@ RSpec.describe MoveValidator do
   let(:move_validator) { MoveValidator.new }
   let(:board) { Board.new }
 
-  describe 'error_for_move' do
+  describe 'move_error' do
     it 'should return true given an integer as a string' do
-      error_symbol = move_validator.error_for_move(board, '2')
+      error_symbol = move_validator.move_error(board, '2')
 
       expect(error_symbol).to be nil
     end
 
     it 'should return true given an integer as a string surrounded by whitespace' do
-      error_symbol = move_validator.error_for_move(board, ' 2 ')
+      error_symbol = move_validator.move_error(board, ' 2 ')
 
       expect(error_symbol).to be nil
     end
 
     it 'should return false given a non-integer string' do
-      error_symbol = move_validator.error_for_move(board, '1one')
+      error_symbol = move_validator.move_error(board, '1one')
 
       expect(error_symbol).to eq :not_valid_integer
     end
 
     it 'should return false given a float' do
-      error_symbol = move_validator.error_for_move(board, 1.0)
+      error_symbol = move_validator.move_error(board, 1.0)
 
       expect(error_symbol).to eq :not_valid_integer
     end
 
     it 'should return false given nil' do
-      error_symbol = move_validator.error_for_move(board, nil)
+      error_symbol = move_validator.move_error(board, nil)
 
       expect(error_symbol).to eq :not_valid_integer
     end
 
     it 'should return false given white space' do
-      error_symbol = move_validator.error_for_move(board, ' ')
+      error_symbol = move_validator.move_error(board, ' ')
 
       expect(error_symbol).to eq :not_valid_integer
     end
 
     it 'should return false given special characters' do
-      error_symbol = move_validator.error_for_move(board, '!')
+      error_symbol = move_validator.move_error(board, '!')
 
       expect(error_symbol).to eq :not_valid_integer
     end
 
     it 'should return true given the square is empty' do
-      error_symbol = move_validator.error_for_move(board, 1)
+      error_symbol = move_validator.move_error(board, 1)
 
       expect(error_symbol).to be nil
     end
 
     it 'should return false given a position less than 1' do
-      error_symbol = move_validator.error_for_move(board, 0)
+      error_symbol = move_validator.move_error(board, 0)
 
       expect(error_symbol).to eq :square_unavailable
     end
 
     it 'should return false given a position greater than 9' do
-      error_symbol = move_validator.error_for_move(board, 10)
+      error_symbol = move_validator.move_error(board, 10)
 
       expect(error_symbol).to eq :square_unavailable
     end
@@ -79,7 +79,7 @@ RSpec.describe MoveValidator do
 
       board.instance_variable_set(:@board, board_played_at_one)
 
-      error_symbol = move_validator.error_for_move(board, 1)
+      error_symbol = move_validator.move_error(board, 1)
 
       expect(error_symbol).to eq :square_unavailable
     end

--- a/spec/lib/move_validator_spec.rb
+++ b/spec/lib/move_validator_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe MoveValidator do
 
     it 'should return false given a non-integer string' do
       expect(game_messenger).to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).not_to receive(:display).with(message: :square_unavaliable)
+      expect(game_messenger).not_to receive(:display).with(message: :square_unavailable)
 
       is_valid = move_validator.move_valid?(board, '1one')
 
@@ -33,7 +33,7 @@ RSpec.describe MoveValidator do
 
     it 'should return false given a float' do
       expect(game_messenger).to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).not_to receive(:display).with(message: :square_unavaliable)
+      expect(game_messenger).not_to receive(:display).with(message: :square_unavailable)
 
       is_valid = move_validator.move_valid?(board, 1.0)
 
@@ -42,7 +42,7 @@ RSpec.describe MoveValidator do
 
     it 'should return false given nil' do
       expect(game_messenger).to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).not_to receive(:display).with(message: :square_unavaliable)
+      expect(game_messenger).not_to receive(:display).with(message: :square_unavailable)
 
       is_valid = move_validator.move_valid?(board, nil)
 
@@ -51,7 +51,7 @@ RSpec.describe MoveValidator do
 
     it 'should return false given white space' do
       expect(game_messenger).to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).not_to receive(:display).with(message: :square_unavaliable)
+      expect(game_messenger).not_to receive(:display).with(message: :square_unavailable)
 
       is_valid = move_validator.move_valid?(board, ' ')
 
@@ -60,7 +60,7 @@ RSpec.describe MoveValidator do
 
     it 'should return false given special characters' do
       expect(game_messenger).to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).not_to receive(:display).with(message: :square_unavaliable)
+      expect(game_messenger).not_to receive(:display).with(message: :square_unavailable)
 
       is_valid = move_validator.move_valid?(board, '!')
 
@@ -75,7 +75,7 @@ RSpec.describe MoveValidator do
 
     it 'should return false given a position less than 1' do
       expect(game_messenger).not_to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).to receive(:display).with(message: :square_unavaliable)
+      expect(game_messenger).to receive(:display).with(message: :square_unavailable)
 
       is_valid = move_validator.move_valid?(board, 0)
 
@@ -84,7 +84,7 @@ RSpec.describe MoveValidator do
 
     it 'should return false given a position greater than 9' do
       expect(game_messenger).not_to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).to receive(:display).with(message: :square_unavaliable)
+      expect(game_messenger).to receive(:display).with(message: :square_unavailable)
 
       is_valid = move_validator.move_valid?(board, 10)
 
@@ -93,7 +93,7 @@ RSpec.describe MoveValidator do
 
     it 'should return false if the square is occupied' do
       expect(game_messenger).not_to receive(:display).with(message: :not_valid_integer)
-      expect(game_messenger).to receive(:display).with(message: :square_unavaliable)
+      expect(game_messenger).to receive(:display).with(message: :square_unavailable)
 
       board_played_at_one = [
         ['X', nil, nil],

--- a/spec/lib/tic_tac_toe_spec.rb
+++ b/spec/lib/tic_tac_toe_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe TicTacToe do
     it 'should display welcome, instructions, the board, and prompt a move' do
       game_spy = spy('game')
 
+      expect(ui).to receive(:clear_output).once.ordered
       expect(tic_tac_toe).to receive(:display_welcome).once.ordered
       expect(tic_tac_toe).to receive(:create_a_game).once.ordered.and_return(game_spy)
       expect(game_spy).to receive(:start).once.ordered

--- a/spec/lib/user_interface_spec.rb
+++ b/spec/lib/user_interface_spec.rb
@@ -2,28 +2,6 @@ require_relative '../../lib/user_interface'
 require_relative '../../lib/cli'
 require_relative '../../lib/board'
 
-# class TestCLI
-#   attr_reader :diplayed_messages
-#   def initialize
-#     @diplayed_messages = []
-#   end
-
-#   def display_message(message)
-#     @diplayed_messages.push message
-#   end
-
-#   def display_board(board_state)
-#     return nil unless board_state.is_a? Array
-
-#     board_str = board_state.flatten.map { |square| square || 'nil' }
-#     @diplayed_messages.push board_str.join(',')
-#   end
-
-#   def clear_output
-#     true
-#   end
-# end
-
 RSpec.describe UserInterface do
   let(:cli) { TestCLI.new }
   let(:user_interface) { UserInterface.new(cli) }

--- a/spec/lib/user_interface_spec.rb
+++ b/spec/lib/user_interface_spec.rb
@@ -2,33 +2,55 @@ require_relative '../../lib/user_interface'
 require_relative '../../lib/cli'
 require_relative '../../lib/board'
 
+class TestCLI
+  def display_message(text)
+    "Displayed: #{text}"
+  end
+
+  def display_board(board_state)
+    return nil unless board_state.is_a? Array
+
+    board_str = board_state.flatten.map { |square| square || 'nil' }
+    board_str.join(',')
+  end
+
+  def clear_output
+    'Cleared!'
+  end
+end
+
 RSpec.describe UserInterface do
-  let(:cli) { CLI.new }
+  let(:cli) { TestCLI.new }
   let(:user_interface) { UserInterface.new(cli) }
 
   describe 'initialize' do
     it 'should set @platform to the CLI instance' do
       private_cli = user_interface.instance_variable_get(:@platform)
-      expect(private_cli).to be_kind_of CLI
+      expect(private_cli).to be_kind_of TestCLI
     end
   end
 
   describe 'display_message' do
     it 'should call CLI#display_message with the string argument passed in' do
       text = 'This should is a text'
+      diplayed = user_interface.display_message text
 
-      expect(cli).to receive(:display_message).with(text).once
-
-      user_interface.display_message text
+      expect(diplayed).to eq "Displayed: #{text}"
     end
   end
 
   describe 'display_board' do
     it 'should call CLI#display_message with formatted board' do
       board = Board.new
-      expect(cli).to receive(:display_board).with(board.state).once
+      board_str = user_interface.display_board board.state
 
-      user_interface.display_board board.state
+      expect(board_str).to eq 'nil,nil,nil,nil,nil,nil,nil,nil,nil'
+    end
+  end
+
+  describe 'clear_output' do
+    it 'should call CLI#display_message with formatted board' do
+      expect(user_interface.clear_output).to eq 'Cleared!'
     end
   end
 end

--- a/spec/lib/user_interface_spec.rb
+++ b/spec/lib/user_interface_spec.rb
@@ -3,19 +3,24 @@ require_relative '../../lib/cli'
 require_relative '../../lib/board'
 
 class TestCLI
-  def display_message(text)
-    "Displayed: #{text}"
+  attr_reader :diplayed_message
+  def initialize
+    @diplayed_message = []
+  end
+
+  def display_message(message)
+    @diplayed_message.push message
   end
 
   def display_board(board_state)
     return nil unless board_state.is_a? Array
 
     board_str = board_state.flatten.map { |square| square || 'nil' }
-    board_str.join(',')
+    @diplayed_message.push board_str.join(',')
   end
 
   def clear_output
-    'Cleared!'
+    true
   end
 end
 
@@ -31,26 +36,32 @@ RSpec.describe UserInterface do
   end
 
   describe 'display_message' do
-    it 'should call CLI#display_message with the string argument passed in' do
-      text = 'This should is a text'
-      diplayed = user_interface.display_message text
+    it 'should print the message' do
+      message = 'This was written at PencilWorks'
+      user_interface.display_message message
 
-      expect(diplayed).to eq "Displayed: #{text}"
+      test_cli = user_interface.instance_variable_get(:@platform)
+
+      expect(test_cli.diplayed_message.length).to eq 1
+      expect(test_cli.diplayed_message.last).to eq message
     end
   end
 
   describe 'display_board' do
-    it 'should call CLI#display_message with formatted board' do
+    it 'should print the board' do
       board = Board.new
-      board_str = user_interface.display_board board.state
+      user_interface.display_board board.state
 
-      expect(board_str).to eq 'nil,nil,nil,nil,nil,nil,nil,nil,nil'
+      test_cli = user_interface.instance_variable_get(:@platform)
+
+      expect(test_cli.diplayed_message.length).to eq 1
+      expect(test_cli.diplayed_message.last).to eq 'nil,nil,nil,nil,nil,nil,nil,nil,nil'
     end
   end
 
   describe 'clear_output' do
-    it 'should call CLI#display_message with formatted board' do
-      expect(user_interface.clear_output).to eq 'Cleared!'
+    it 'should clear outputs' do
+      expect(user_interface.clear_output).to eq true
     end
   end
 end

--- a/spec/lib/user_interface_spec.rb
+++ b/spec/lib/user_interface_spec.rb
@@ -2,27 +2,27 @@ require_relative '../../lib/user_interface'
 require_relative '../../lib/cli'
 require_relative '../../lib/board'
 
-class TestCLI
-  attr_reader :diplayed_message
-  def initialize
-    @diplayed_message = []
-  end
+# class TestCLI
+#   attr_reader :diplayed_messages
+#   def initialize
+#     @diplayed_messages = []
+#   end
 
-  def display_message(message)
-    @diplayed_message.push message
-  end
+#   def display_message(message)
+#     @diplayed_messages.push message
+#   end
 
-  def display_board(board_state)
-    return nil unless board_state.is_a? Array
+#   def display_board(board_state)
+#     return nil unless board_state.is_a? Array
 
-    board_str = board_state.flatten.map { |square| square || 'nil' }
-    @diplayed_message.push board_str.join(',')
-  end
+#     board_str = board_state.flatten.map { |square| square || 'nil' }
+#     @diplayed_messages.push board_str.join(',')
+#   end
 
-  def clear_output
-    true
-  end
-end
+#   def clear_output
+#     true
+#   end
+# end
 
 RSpec.describe UserInterface do
   let(:cli) { TestCLI.new }
@@ -42,8 +42,8 @@ RSpec.describe UserInterface do
 
       test_cli = user_interface.instance_variable_get(:@platform)
 
-      expect(test_cli.diplayed_message.length).to eq 1
-      expect(test_cli.diplayed_message.last).to eq message
+      expect(test_cli.diplayed_messages.length).to eq 1
+      expect(test_cli.diplayed_messages.last).to eq message
     end
   end
 
@@ -54,8 +54,8 @@ RSpec.describe UserInterface do
 
       test_cli = user_interface.instance_variable_get(:@platform)
 
-      expect(test_cli.diplayed_message.length).to eq 1
-      expect(test_cli.diplayed_message.last).to eq 'nil,nil,nil,nil,nil,nil,nil,nil,nil'
+      expect(test_cli.diplayed_messages.length).to eq 1
+      expect(test_cli.diplayed_messages.last).to eq 'nil,nil,nil,nil,nil,nil,nil,nil,nil'
     end
   end
 


### PR DESCRIPTION
This will clear any board and messages when there is an update. The idea is to prevent clutter and make sure that the board is visible.

Currently, error messages are in #11, so I will wait for that PR to be merge before continuing.